### PR TITLE
Remove public_url and assume secure_url for now

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -36,9 +36,6 @@ class Photo < ActiveRecord::Base
   validates_presence_of :checksum
   validates_uniqueness_of :checksum, :scope => :user_id
 
-  # Public: Public url to photo if photo is public.
-  # column :public_url
-
   # Public: Set attributes from uploaded file.
   #
   # uploaded_file - ActionDispatch::Http::UploadedFile instance.
@@ -48,7 +45,6 @@ class Photo < ActiveRecord::Base
     self.filename   = ::Utf8.force_encoding(uploaded_file.original_filename)
     self.checksum   = upload.checksum
     self.path       = upload.path
-    self.public_url = upload.public_url
   end
 
   # Public: Extension for uploaded file.
@@ -64,7 +60,7 @@ class Photo < ActiveRecord::Base
   #
   # Returns a String.
   def url
-    public_url || secure_url
+    secure_url
   end
 
   # Public: Persisted photo object from Fog.

--- a/db/migrate/20131223054227_add_public_url_to_photo.rb
+++ b/db/migrate/20131223054227_add_public_url_to_photo.rb
@@ -1,5 +1,0 @@
-class AddPublicUrlToPhoto < ActiveRecord::Migration
-  def change
-    add_column :photos, :public_url, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131223054227) do
+ActiveRecord::Schema.define(version: 20131223000047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,6 @@ ActiveRecord::Schema.define(version: 20131223054227) do
     t.string   "path",           null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "public_url"
   end
 
   add_index "photos", ["photo_store_id", "path"], name: "index_photos_on_photo_store_id_and_path", unique: true, using: :btree


### PR DESCRIPTION
This is in preparation for a state machine on photo + we don't need to store the public url, it can be calculated cheaply (concat a few strings).
